### PR TITLE
feature: adding windows and freebsd to build release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,14 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
+      - freebsd
+    goarm:
+      - 6
+      - 7
+    goamd64:
+      - v2
+      - v3
 
 release:
   prerelease: auto


### PR DESCRIPTION
This PR adds windows and freebsd builds, as well as tighter control on ARM and AMD-64 build versioning.