### PR TITLE
support: remove freeBSD until workflow is solid

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,6 @@ builds:
       - linux
       - darwin
       - windows
-      - freebsd
     goarm:
       - 6
       - 7


### PR DESCRIPTION
The FreeBSD build is breaking CI, so removing for now until a local development workflow has been created to ensure speedier reliable builds can be had.